### PR TITLE
Changes to support running on cloud9

### DIFF
--- a/server.js
+++ b/server.js
@@ -2,14 +2,22 @@ var webpack = require('webpack');
 var WebpackDevServer = require('webpack-dev-server');
 var config = require('./webpack.config');
 
+//var host = 'localhost'
+// var port = '3000'
+
+//will help to run it on cloud9 (c9.io)
+var host = process.env.IP ; 
+var port = process.env.PORT ; 
+
+
 new WebpackDevServer(webpack(config), {
   publicPath: config.output.publicPath,
   hot: true,
   historyApiFallback: true
-}).listen(3000, 'localhost', function (err, result) {
+}).listen(port, host, function (err, result) {
   if (err) {
     console.log(err);
   }
 
-  console.log('Listening at localhost:3000');
+  console.log('Listening at ' + host + port);
 });

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,10 +1,17 @@
 var path = require('path');
 var webpack = require('webpack');
 
+//var host = 'localhost'
+// var port = '3000'
+
+//will help to run it on cloud9 (c9.io)
+var host = process.env.IP ; 
+var port = process.env.PORT ; 
+
 module.exports = {
   devtool: 'eval',
   entry: [
-    'webpack-dev-server/client?http://localhost:3000',
+    'webpack-dev-server/client?https://'+host+':' + port,
     'webpack/hot/only-dev-server',
     './src/index'
   ],


### PR DESCRIPTION
These changes will help with binding the IP and port so you can run it on C9 and hit it from a browser.

To test it out on cloud 9 (once your account is set up and you are in the terminal/shell)

git clone https://github.com/hedgerh/thinkful-es6-workshop.git
cd thinkful-es6-workshop
sudo npm install
npm start

you should be able to open a browser to 
https:// your workspace name - your account name .c9.io/

Feel free to reject this PR if it isn't close enough to how you'd do it. (I'm just doing the PR so you see it)
